### PR TITLE
Segment all datasets when pushing to Coda

### DIFF
--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -15,26 +15,14 @@ DATA_ROOT=$3
 ./checkout_coda_v2.sh "$CODA_V2_ROOT"
 
 PROJECT_NAME="WorldBank-PLR"
-DATASETS=(
-    "gender"
-    "age"
-    "recently_displaced"
-    "in_idp_camp"
-)
-
-cd "$CODA_V2_ROOT/data_tools"
-git checkout "6e4b5e280b0baded86bc2afbf27f44f542e1aeed"  # (master before we started work on segmenting)
-
-for DATASET in ${DATASETS[@]}
-do
-    echo "Pushing messages data to ${PROJECT_NAME}_${DATASET}..."
-
-    pipenv run python add.py "$AUTH" "${PROJECT_NAME}_${DATASET}" messages "$DATA_ROOT/Outputs/Coda Files/$DATASET.json"
-done
 
 DATASETS=(
     "s05e01"
 
+    "gender"
+    "age"
+    "recently_displaced"
+    "in_idp_camp"
     "location"
 )
 


### PR DESCRIPTION
(This came out of the G&A post-mortem. Segmenting everything is simpler to maintain).