### PR TITLE
Remove opt-in code from Somalia Operator scheme

### DIFF
--- a/code_schemes/somalia_operator.json
+++ b/code_schemes/somalia_operator.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-f86cff0b",
   "Name": "Somalia Operator",
-  "Version": "0.0.0.2",
+  "Version": "0.0.1.0",
   "Codes": [
     {
       "CodeID": "code-450ec146",

--- a/code_schemes/somalia_operator.json
+++ b/code_schemes/somalia_operator.json
@@ -88,15 +88,6 @@
       "VisibleInCoda": true
     },
     {
-      "CodeID": "code-OI-c5f1d054",
-      "CodeType": "Meta",
-      "MetaCode": "opt-in",
-      "DisplayText": "opt-in",
-      "NumericValue": -100040,
-      "StringValue": "opt_in",
-      "VisibleInCoda": true
-    },
-    {
       "CodeID": "code-STOP-08b832a8",
       "CodeType": "Control",
       "ControlCode": "STOP",


### PR DESCRIPTION
This scheme doesn't get applied to manually labelled free-text, so it doesn't make sense to have this code on this scheme.