### PR TITLE
Update the scheme version numbers to match those in standards

### DIFF
--- a/code_schemes/age.json
+++ b/code_schemes/age.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-4189e74c",
   "Name": "Age",
-  "Version": "0.0.0.3",
+  "Version": "0.0.0.4",
   "Codes": [
     {
       "CodeID": "code-a3305435",

--- a/code_schemes/gender.json
+++ b/code_schemes/gender.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-12cb6f95",
   "Name": "Gender",
-  "Version": "0.0.0.4",
+  "Version": "0.0.0.5",
   "Codes": [
     {
       "CodeID": "code-63dcde9a",

--- a/code_schemes/in_idp_camp.json
+++ b/code_schemes/in_idp_camp.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-0fe57c6d",
   "Name": "In IDP Camp",
-  "Version": "0.0.0.3",
+  "Version": "0.0.0.4",
   "Codes": [
     {
       "CodeID": "code-dc43b68e",

--- a/code_schemes/mogadishu_sub_district.json
+++ b/code_schemes/mogadishu_sub_district.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-07dfc611",
   "Name": "Mogadishu Sub-District",
-  "Version": "0.0.0.5",
+  "Version": "0.0.0.6",
   "Codes": [
     {
       "CodeID": "code-d170504a",

--- a/code_schemes/recently_displaced.json
+++ b/code_schemes/recently_displaced.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-e1aa9330",
   "Name": "Recently Displaced",
-  "Version": "0.0.0.3",
+  "Version": "0.0.0.4",
   "Codes": [
     {
       "CodeID": "code-2b565901",

--- a/code_schemes/somalia_district.json
+++ b/code_schemes/somalia_district.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-5292e8fb",
   "Name": "Somalia District",
-  "Version": "0.0.0.5",
+  "Version": "0.0.0.6",
   "Codes": [
     {
       "CodeID": "code-acc06b14",

--- a/code_schemes/somalia_region.json
+++ b/code_schemes/somalia_region.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-644e3296",
   "Name": "Somalia Region",
-  "Version": "0.0.0.5",
+  "Version": "0.0.0.6",
   "Codes": [
     {
       "CodeID": "code-8af5ec4f",

--- a/code_schemes/somalia_state.json
+++ b/code_schemes/somalia_state.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-a390e6ce",
   "Name": "Somalia State",
-  "Version": "0.0.0.5",
+  "Version": "0.0.0.6",
   "Codes": [
     {
       "CodeID": "code-3951a76e",

--- a/code_schemes/somalia_zone.json
+++ b/code_schemes/somalia_zone.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-b8ce44fb",
   "Name": "Somalia Zone",
-  "Version": "0.0.0.5",
+  "Version": "0.0.0.6",
   "Codes": [
     {
       "CodeID": "code-af199806",


### PR DESCRIPTION
These were bumped in Standards but not here. The codes are the same.