### PR TITLE
Set the ws_code field of the evaluation question coding plans

### DIFF
--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -257,6 +257,7 @@ class PipelineConfiguration(object):
                            folding_mode=FoldingModes.MATRIX  # TODO: Assert equal?
                        )
                    ],
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("responsible"),
                    raw_field_folding_mode=FoldingModes.ASSERT_EQUAL),
 
         CodingPlan(raw_field="solve_problems_raw",
@@ -271,6 +272,7 @@ class PipelineConfiguration(object):
                            folding_mode=FoldingModes.MATRIX  # TODO: Assert equal?
                        )
                    ],
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("solve problems"),
                    raw_field_folding_mode=FoldingModes.ASSERT_EQUAL),
 
         CodingPlan(raw_field="have_voice_raw",
@@ -286,6 +288,7 @@ class PipelineConfiguration(object):
                            folding_mode=FoldingModes.ASSERT_EQUAL
                        )
                    ],
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("have voice"),
                    raw_field_folding_mode=FoldingModes.ASSERT_EQUAL)
     ]
 


### PR DESCRIPTION
Now that we added these to the WS Correct Dataset scheme in #35 we should add them to configuration so we can actually use them to move WS messages.